### PR TITLE
Remove VERCEL_URL fallback from createTrackedDownloadUrl function in …

### DIFF
--- a/packages/api/modules/uploads/procedures/tracked-download.ts
+++ b/packages/api/modules/uploads/procedures/tracked-download.ts
@@ -33,10 +33,6 @@ export const createTrackedDownloadUrl = publicProcedure
         return process.env.NEXT_PUBLIC_BASE_URL;
       }
       
-      if (process.env.VERCEL_URL) {
-        return `https://${process.env.VERCEL_URL}`;
-      }
-      
       // Development fallback
       return "http://localhost:3000";
     };


### PR DESCRIPTION
…tracked-download.ts for cleaner environment handling. This change simplifies the URL generation logic by relying solely on the NEXT_PUBLIC_BASE_URL and localhost for development.