### PR TITLE
Update app branding with new logo assets

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -52,12 +52,12 @@ export default async function RootLayout({
         <meta name="apple-mobile-web-app-title" content="Gallery Wall" />
 
         {/* Apple Touch Icons */}
-        <link rel="apple-touch-icon" href="/images/pub-logo-transparent.webp" />
+        <link rel="apple-touch-icon" href="/images/riding-the-tides-logo.webp" />
 
         {/* Windows/MS */}
         <meta
           name="msapplication-TileImage"
-          content="/images/pub-logo-transparent.webp"
+          content="/images/riding-the-tides-logo.webp"
         />
         <meta name="msapplication-TileColor" content="#2563eb" />
 

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -11,25 +11,25 @@
   "prefer_related_applications": false,
   "icons": [
     {
-      "src": "/images/pub-logo-transparent.webp",
+      "src": "/images/riding-the-tides-logo.webp",
       "sizes": "192x192",
       "type": "image/webp",
       "purpose": "any"
     },
     {
-      "src": "/images/pub-logo-transparent.webp",
+      "src": "/images/riding-the-tides-logo.webp",
       "sizes": "192x192",
       "type": "image/webp",
       "purpose": "maskable"
     },
     {
-      "src": "/images/pub-logo-transparent.webp",
+      "src": "/images/riding-the-tides-logo.webp",
       "sizes": "512x512",
       "type": "image/webp",
       "purpose": "any"
     },
     {
-      "src": "/images/pub-logo-transparent.webp",
+      "src": "/images/riding-the-tides-logo.webp",
       "sizes": "512x512",
       "type": "image/webp",
       "purpose": "maskable"

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -4,7 +4,7 @@ const urlsToCache = [
   "/favicon.ico",
   "/images/background.svg",
   "/images/hero.svg",
-  "/images/pub-logo-transparent.webp",
+  "/images/riding-the-tides-logo.webp",
   // Add other critical assets that should be cached
 ];
 


### PR DESCRIPTION
Updated the application's branding by replacing old logo assets with the new logo, "riding-the-tides-logo.webp", across `manifest.json`, `layout.tsx`, and service worker files. This ensures consistent use of the updated branding throughout the application.